### PR TITLE
feat: remove some variables to reduce memory footprint

### DIFF
--- a/lib/utils/getAbsolutePath.js
+++ b/lib/utils/getAbsolutePath.js
@@ -1,4 +1,5 @@
-const { resolve, isAbsolute, extname } = require("path");
+const { resolve, isAbsolute, extname ,isDirectory} = require("path");
+const fs = require("fs");
 
 /**
  *
@@ -7,7 +8,7 @@ const { resolve, isAbsolute, extname } = require("path");
  * @param {*} isDir //是否是文件夹 默认是文件
  * @returns //完整路径
  */
-function getAbsolutePath(context, path, extensions = [], isDir = false) {
+function getAbsolutePath( path, extensions = []) {
   let absolutePath;
   //如果是绝对路径
   if (isAbsolute(path)) {
@@ -15,10 +16,11 @@ function getAbsolutePath(context, path, extensions = [], isDir = false) {
   }
   //如果是相对路径
   else {
-    absolutePath = resolve(context, path);
+    absolutePath = resolve(path);
   }
   //如果不是文件夹则添加后缀
-  if (!isDir) {
+  const  stat = fs.lstatSync(absolutePath);
+  if (!stat.isDirectory()) {
     //给路径添加.js后缀
     const index = extensions.indexOf(extname(absolutePath));
     absolutePath = index === -1 ? createError(absolutePath) : absolutePath;
@@ -28,7 +30,7 @@ function getAbsolutePath(context, path, extensions = [], isDir = false) {
 
 function createError(absolutePath) {
   throw new Error(
-    `Can not find file at '${absolutePath}'. Maybe you should add params 'extensions',its default value includes [
+    `Can not find the file at '${absolutePath}'. Maybe you should add params 'extensions',its default value includes [
     ".js",
     ".vue",
     ".html",
@@ -43,5 +45,6 @@ function createError(absolutePath) {
   ]`
   );
 }
+
 
 module.exports = getAbsolutePath;

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -5,7 +5,7 @@ const watchFile = require("./watchFile");
 const fs = require("fs");
 
 function _watch(path, changeCallback, options, resultCallback) {
-  const absolutePath = getAbsolutePath(process.cwd(), path, [], true);
+  const absolutePath = getAbsolutePath( path, []);
   //这是文件夹
   if (fs.statSync(absolutePath).isDirectory()) {
     watchDir(absolutePath, changeCallback, options, function (cancel) {

--- a/lib/watchDir.js
+++ b/lib/watchDir.js
@@ -28,12 +28,10 @@ function watchDir(
   options.extensions = options.extensions || _extensions;
   options.poll = options.poll || 10;
   const { deep, extensions, poll } = options;
-  const context = process.cwd(); //获取当前文件的上下文
+  // const context = process.cwd(); //获取当前文件的上下文
   const absolutePath = getAbsolutePath(
-    context,
     dirPath,
     extensions, //拓展名
-    true /*是文件夹*/
   );
   const dirChildPath = []; //当前监听文件夹下面所有文件的路径
   const watchFileDataArr = []; //存放所有监听文件的信息和取消监听方法

--- a/lib/watchDirSync.js
+++ b/lib/watchDirSync.js
@@ -24,12 +24,12 @@ function watchDirSync(dirPath, changeCallback, options = {}, isRoot = true) {
   options.poll = options.poll || 10;
   //向下传递的参数不需要在验证参数
   const { deep, extensions, poll } = options;
-  const context = process.cwd(); //获取当前文件的上下文
+  // const context = process.cwd(); //获取当前文件的上下文
   const absolutePath = getAbsolutePath(
-    context,
+    // context,
     dirPath,
     extensions, //拓展名
-    true /*是文件夹*/
+    // true /*是文件夹*/
   );
   const dirChildPath = []; //当前监听文件夹下面所有文件的路径
   const watchFileDataArr = []; //存放所有监听文件的信息和取消监听方法

--- a/lib/watchExist.js
+++ b/lib/watchExist.js
@@ -11,7 +11,7 @@ function watchExist(
   resultCallback = () => {}
 ) {
   const { poll = 10 } = options;
-  const absolutePath = getAbsolutePath(process.cwd(), filePath, [], true);
+  const absolutePath = getAbsolutePath( filePath, []);
   RoundListening(
     absolutePath,
     1000 / poll,

--- a/lib/watchFile.js
+++ b/lib/watchFile.js
@@ -19,7 +19,7 @@ function watchFile(
   resultCallback = () => {}
 ) {
   validWatchFileOrDirArguments(true, ...arguments);
-  const context = process.cwd(); //获取当前文件的上下文
+  // const context = process.cwd(); //获取当前文件的上下文
   const {
     poll = 10, //用于标识每秒询问多少次 默认值为10
     isContent = false, //用于标识回调函数得参数中是否包含文件内容content
@@ -27,7 +27,7 @@ function watchFile(
     monitorTimeChange = false,
     extensions = _extensions,
   } = options;
-  const absolutePath = getAbsolutePath(context, filePath, extensions);
+  const absolutePath = getAbsolutePath( filePath, extensions);
   const eachTime = 1000 / poll; //每次轮询的时间
   //如果文件存在的话
   if (exists(absolutePath)) {

--- a/lib/watchFileSync.js
+++ b/lib/watchFileSync.js
@@ -18,7 +18,7 @@ function watchFileSync(filePath, changeCallback, options = {}) {
   let cancelWatchFile;
   //向下传递的参数不需要在验证参数
   const { extensions = _extensions } = options;
-  const context = process.cwd(); //获取当前文件的上下文
+  // const context = process.cwd(); //获取当前文件的上下文
   const {
     poll = 10, //用于标识每秒询问多少次 默认值为10
     isContent = true, //用于标识回调函数得参数中是否包含文件内容content
@@ -26,7 +26,7 @@ function watchFileSync(filePath, changeCallback, options = {}) {
     monitorTimeChange = false,
   } = options;
 
-  const absolutePath = getAbsolutePath(context, filePath, extensions);
+  const absolutePath = getAbsolutePath( filePath, extensions);
   const eachTime = 1000 / poll; //每次轮询的时间
   //如果文件存在的话
   if (exists(absolutePath)) {

--- a/lib/watchSync.js
+++ b/lib/watchSync.js
@@ -5,7 +5,7 @@ const watchFileSync = require("./watchFileSync");
 const fs = require("fs");
 
 function _watchSync(path, changeCallback, options = {}) {
-  const absolutePath = getAbsolutePath(process.cwd(), path, [], true);
+  const absolutePath = getAbsolutePath( path, []);
   let cancel;
   //这是文件夹
   if (fs.statSync(absolutePath).isDirectory()) {

--- a/test.js
+++ b/test.js
@@ -12,19 +12,19 @@ const { resolve } = require("path");
 // cancel();
 // }, 5000);
 
-// watch.watchFile(
-// "./test.js",
-// function (data) {
-// console.log(data);
-// },
-// { monitorTimeChange: true },
-// function (cancel) {
-// console.log("111");
-// setTimeout(() => {
-// cancel();
-// }, 5000);
-// }
-// );
+watch.watchFile(
+  "./test.js",
+  function (data) {
+    console.log(data);
+  },
+  { monitorTimeChange: true },
+  function (cancel) {
+    console.log("111");
+    setTimeout(() => {
+      cancel();
+    }, 5000);
+  }
+);
 
 // watch.watchDir(
 // "./a",
@@ -59,11 +59,11 @@ const { resolve } = require("path");
 // }
 // );
 
-const cancel = watch.watchSync(
-  ["./a", "./lib"],
-  function (data) {
-    console.log(data);
-  },
-  { monitorTimeChange: true, deep: true }
-);
+// const cancel = watch.watchSync(
+//   ["./a", "./lib"],
+//   function (data) {
+//     console.log(data);
+//   },
+//   { monitorTimeChange: true, deep: true }
+// );
 // cancel();


### PR DESCRIPTION
I think we can enhance the readability of our code by minimizing artificial variables when calculating absolute paths. For example, the original isDir variable is used to determine whether it is a folder. We can use the isDirectory API to solve the problem of generating extra variables. These are just my tiny suggestions.